### PR TITLE
IBX-84: Added REST eZ Commerce for 3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "ezsystems/ezcommerce-erp-admin": "^3.3.x-dev",
         "ezsystems/ezcommerce-order-history": "^3.3.x-dev",
         "ezsystems/ezcommerce-page-builder": "^1.2.x-dev",
+        "ezsystems/ezcommerce-rest": "^3.0.x-dev",
         "ezsystems/ezcommerce-transaction": "^1.0.x-dev"
     },
     "extra": {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | IBX-84
| **Type**                                   | feature
| **Target Ibexa version** | `v3.3.3`
| **BC breaks**                          | no
| **Doc needed**                       | no (already provided)

Adds `ezsystems/ezcommerce-rest` as a dependency.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [ ] Asked for a review (ping `@ibexa/engineering`).
