### PR TITLE
IBX-4145: Updated changelog generator

### DIFF
--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-      - '!v*-alpha*'
 
 jobs:
   provide_changed_packages:
@@ -24,13 +23,22 @@ jobs:
         name: Gather latest package information
         run: |
           OUT=$(jq --slurp '[.[].packages[] | select(.name | contains("ezsystems") or contains("ibexa")) | [.name, .version] | { name: (.[0]), version: .[1] }]' composer.lock)
-          echo "::set-output name=lock::$( echo "$OUT" | sed ':a;N;$!ba;s/\n/%0A/g' )"
+          echo "lock=$( echo "$OUT" | sed ':a;N;$!ba;s/\n//g' )" >> $GITHUB_OUTPUT
+
+      - name: Get previous last full release
+        id: prevfull
+        run: |
+          OUT=$(hub api /repos/${{ github.repository }}/releases | jq -r -s '[ .[][].tag_name | select(. | contains("rc") or contains("beta") or contains("alpha") | not) ] | first')
+          echo "tag=$( echo "$OUT" )" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get previous release tag based on type
         id: prevrelease
         uses: ibexa/version-logic-action@master
         with:
           currentTag: ${{ env.BUILD_TAG }}
+          prevFullTag: ${{ steps.prevfull.outputs.tag }}
 
       # checkout previous tag
       - uses: actions/checkout@v2
@@ -42,7 +50,7 @@ jobs:
         name: Gather previous package information
         run: |
           OUT=$(jq --slurp '[.[].packages[] | select(.name | contains("ezsystems") or contains("ibexa")) | [.name, .version] | { name: (.[0]), version: .[1] }]' composer.lock)
-          echo "::set-output name=lock::$( echo "$OUT" | sed ':a;N;$!ba;s/\n/%0A/g' )"
+          echo "lock=$( echo "$OUT" | sed ':a;N;$!ba;s/\n//g' )" >> $GITHUB_OUTPUT
 
       # do some magic comparing those outputs
       - id: output_data
@@ -64,7 +72,7 @@ jobs:
           # Step 5: (outer brackets) Wrap that into JSON list of objects
           # Note: zzzz is added as an additional suffix to properly sort out alpha/beta/etc pre-releases (v2.5.1-alphazzzz < v2.5.1zzzz)
           OUT=$(jq -s 'flatten | group_by(.name)' $FILE1 $FILE2 | jq -s '[ .[][] | {name: (.[0].name), versions: [ .[0].version, .[1].version ] | unique} | select(.versions | length > 1) ] | .[].versions |= sort_by( . + "zzzz" | [scan("[0-9]+|[a-z]+")] | map(tonumber? // .) )')
-          echo "::set-output name=matrix::$( echo "$OUT" | sed ':a;N;$!ba;s/\n/%0A/g' )"
+          echo "matrix=$( echo "$OUT" | sed ':a;N;$!ba;s/\n//g' )" >> $GITHUB_OUTPUT
 
     # this step is needed, so the output gets to the next defined job
     outputs:
@@ -123,7 +131,9 @@ jobs:
             python main.py >> generator_output
             echo '' >> generator_output
           done
-          echo "::set-output name=output::$( cat generator_output | sed ':a;N;$!ba;s/\n/%0A/g' )"
+          echo "CHANGELOG_OUTPUT<<EOF" >> $GITHUB_ENV
+          echo "$(cat generator_output)" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Create Release
         id: create_release
@@ -131,7 +141,7 @@ jobs:
         with:
           tag_name: ${{ env.BUILD_TAG }}
           body: |
-            ${{ steps.generator.outputs.output }}
+            ${{ env.CHANGELOG_OUTPUT }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
As per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/