### PR TITLE
Run regression for IBX-11832

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -19,39 +19,6 @@ on:
     pull_request: ~
 
 jobs:
-    regression-commerce-setup1:
-        name: "PHP 7.4/Node 20/PostgreSQL 18.0/Varnish/Redis 7.2/Multirepository"
-        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
-        with:
-            project-edition: "commerce"
-            project-version: ${{ github.event.inputs.project-version }}
-            test-suite: "--profile=regression --suite=commerce"
-            test-setup-phase-1: "--profile=regression --suite=setup-commerce --tags=~@part2 --mode=standard"
-            test-setup-phase-2: "--profile=regression --suite=setup-commerce --tags=@part2 --mode=standard"
-            setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql18.yml:doc/docker/varnish.yml:doc/docker/redis7.2.yml:doc/docker/selenium.yml"
-            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
-            job-count: 4
-            multirepository: true
-            php-image: "ghcr.io/ibexa/docker/php:7.4-node20"
-            timeout: 120
-        secrets: inherit
-    regression-commerce-setup2:
-        name: "PHP 8.0/Node 20/MariaDB 11.4/Compatibility layer/Elastic 8/Valkey latest"
-        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
-        with:
-            project-edition: "commerce"
-            project-version: ${{ github.event.inputs.project-version }}
-            test-suite: "--profile=regression --suite=commerce"
-            test-setup-phase-1: "--profile=regression --suite=setup-commerce --tags=~@part2 --mode=standard"
-            test-setup-phase-2: "--profile=regression --suite=setup-commerce --tags=@part2 --mode=standard"
-            setup: "doc/docker/base-dev.yml:doc/docker/db-mariadb11.4.yml:doc/docker/elastic8.yml:doc/docker/valkey-latest.yml:doc/docker/selenium.yml"
-            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
-            use-compatibility-layer: true
-            job-count: 4
-            multirepository: true
-            php-image: "ghcr.io/ibexa/docker/php:8.0-node20"
-            timeout: 120
-        secrets: inherit
     regression-commerce-setup3:
         name: "PHP 8.4/Node 22/MySQL 8.4/Multirepository/Solr 8/Redis latest"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,0 +1,23 @@
+{
+    "recipesEndpoint": "",
+    "packages": [
+        {
+            "requirement": "dev-IBX-11832_Let_Ibexa_DXP_support_psr_log_at_least_version_2.0 as 4.6.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/elasticsearch",
+            "package": "ibexa/elasticsearch",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-IBX-11832_Let_Ibexa_DXP_support_psr_log_at_least_version_2.0 as 4.6.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/fieldtype-query",
+            "package": "ibexa/fieldtype-query",
+            "shouldBeAddedAsVCS": false
+        },
+        {
+            "requirement": "dev-IBX-11832_Let_Ibexa_DXP_support_psr_log_at_least_version_2.0 as 4.6.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/corporate-account-commerce-bridge",
+            "package": "ibexa/corporate-account-commerce-bridge",
+            "shouldBeAddedAsVCS": true
+        }
+    ]
+}


### PR DESCRIPTION
> [!CAUTION]
> Do not merge, this is a regression run

| :ticket: Issue | IBX-11832 |
|----------------|-----------|

#### Related PRs:
- https://github.com/ibexa/elasticsearch/pull/78
- https://github.com/ibexa/fieldtype-query/pull/53
- https://github.com/ibexa/corporate-account-commerce-bridge/pull/23
- https://github.com/ibexa/elasticsearch8/pull/3
- https://github.com/ibexa/commerce/pull/1883

#### Description:
Regression run for the IBX-11832 (psr/log 2.x support) PR set: `ibexa/elasticsearch`, `ibexa/fieldtype-query` and `ibexa/corporate-account-commerce-bridge`.

Scope note: this run covers only the Node 22/Solr setup. The two Node 20 setups are disabled by a TMP commit, because on Node 20 images CI force-installs `ibexa/elasticsearch8`, which `replace`s `ibexa/elasticsearch` and therefore cannot coexist with the `ibexa/elasticsearch` PR branch pinned in `dependencies.json`. The `ibexa/elasticsearch8` side-merge branch (https://github.com/ibexa/elasticsearch8/pull/3) is covered separately, on all three setups, by https://github.com/ibexa/commerce/pull/1883.
