### PR TITLE
Run regression for IBX-11832 (ibexa/elasticsearch8)

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,0 +1,23 @@
+{
+    "recipesEndpoint": "",
+    "packages": [
+        {
+            "requirement": "dev-IBX-11832_Let_Ibexa_DXP_support_psr_log_at_least_version_2.0 as 4.6.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/elasticsearch",
+            "package": "ibexa/elasticsearch",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-IBX-11832_Let_Ibexa_DXP_support_psr_log_at_least_version_2.0 as 4.6.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/fieldtype-query",
+            "package": "ibexa/fieldtype-query",
+            "shouldBeAddedAsVCS": false
+        },
+        {
+            "requirement": "dev-IBX-11832_Let_Ibexa_DXP_support_psr_log_at_least_version_2.0 as 4.6.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/corporate-account-commerce-bridge",
+            "package": "ibexa/corporate-account-commerce-bridge",
+            "shouldBeAddedAsVCS": true
+        }
+    ]
+}

--- a/dependencies.json
+++ b/dependencies.json
@@ -2,9 +2,9 @@
     "recipesEndpoint": "",
     "packages": [
         {
-            "requirement": "dev-IBX-11832_Let_Ibexa_DXP_support_psr_log_at_least_version_2.0 as 4.6.x-dev",
-            "repositoryUrl": "https://github.com/ibexa/elasticsearch",
-            "package": "ibexa/elasticsearch",
+            "requirement": "dev-ibx-11832-psr-log-ver-2-support as 4.6.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/elasticsearch8",
+            "package": "ibexa/elasticsearch8",
             "shouldBeAddedAsVCS": true
         },
         {


### PR DESCRIPTION
> [!CAUTION]
> Do not merge, this is a regression run

| :ticket: Issue | IBX-11832 |
|----------------|-----------|

#### Related PRs:
- https://github.com/ibexa/elasticsearch8/pull/3
- https://github.com/ibexa/elasticsearch/pull/78
- https://github.com/ibexa/fieldtype-query/pull/53
- https://github.com/ibexa/corporate-account-commerce-bridge/pull/23
- https://github.com/ibexa/commerce/pull/1853

#### Description:
Regression run for the `ibexa/elasticsearch8` side-merge branch (`ibx-11832-psr-log-ver-2-support`). Split out of https://github.com/ibexa/commerce/pull/1853 because `ibexa/elasticsearch8` replaces `ibexa/elasticsearch`, so the two cannot be required together in one `dependencies.json`.
