### PR TITLE
Verify symfony/serializer 7.4.15 regression in isolation

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,0 +1,4 @@
+{
+    "recipesEndpoint": "",
+    "packages": []
+}


### PR DESCRIPTION
## Purpose

Control experiment, unrelated to any feature work. Isolates whether the
\`ibexa/migrations\` denormalization failure seen on the IBX-12043 regression
run (ibexa/commerce#1905) is caused by anything in that work, or is a
pre-existing incompatibility between \`symfony/serializer\` 7.4.15 and
\`ibexa/migrations\`' custom \`ArrayDenormalizer\` wrapper.

\`dependencies.json\` here is intentionally empty - no \`ibexa/core\`,
\`ibexa/taxonomy\`, or \`ibexa/connector-payum\` overrides, no
\`symfony/serializer\` pin. Just stock \`6.0\` composer resolution.

## Expectation

If \`composer\` resolves \`symfony/serializer\` to \`7.4.15\` on its own here,
and \`ibexa:install\` fails with the same
\`Could not denormalize object of type "...FieldDefinition[]", no supporting
normalizer found\` error during \`2023_12_07_20_23_editor_content_type.yaml\`,
that confirms the bug is entirely independent of IBX-12043 and belongs to
\`ibexa/migrations\` as its own ticket.

## Test plan

- [ ] Confirm resolved \`symfony/serializer\` version in the CI log
- [ ] Confirm whether the denormalization error reproduces
- [ ] Close without merging once confirmed - this PR exists only to run CI