### PR TITLE
[TMP] Run regression for IBX-12043 (DBAL 4)

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -3,7 +3,7 @@ on:
     workflow_dispatch:
         inputs:
             send-success-notification:
-                description: 'Send a notification when the tests pass'     
+                description: 'Send a notification when the tests pass'
                 required: false
                 type: boolean
                 default: false
@@ -21,7 +21,7 @@ on:
 jobs:
     regression-commerce-setup1:
         name: "PHP 8.3/Node 22/PostgreSQL 18.0/Varnish/Redis 7.2/Multirepository"
-        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@k8s-satis
         with:
             project-edition: "commerce"
             project-version: ${{ github.event.inputs.project-version }}
@@ -29,6 +29,7 @@ jobs:
             test-setup-phase-1: "--profile=regression --suite=setup-commerce --tags=~@part2 --mode=standard"
             test-setup-phase-2: "--profile=regression --suite=setup-commerce --tags=@part2 --mode=standard"
             setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql18.yml:doc/docker/varnish.yml:doc/docker/redis7.2.yml:doc/docker/selenium.yml"
+            ci-scripts-branch: "k8s-satis"
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             job-count: 4
             multirepository: true
@@ -37,7 +38,7 @@ jobs:
         secrets: inherit
     regression-commerce-setup2:
         name: "PHP 8.4/Node 22/MariaDB 11.4/Elastic 8/Valkey latest"
-        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@k8s-satis
         with:
             project-edition: "commerce"
             project-version: ${{ github.event.inputs.project-version }}
@@ -45,6 +46,7 @@ jobs:
             test-setup-phase-1: "--profile=regression --suite=setup-commerce --tags=~@part2 --mode=standard"
             test-setup-phase-2: "--profile=regression --suite=setup-commerce --tags=@part2 --mode=standard"
             setup: "doc/docker/base-dev.yml:doc/docker/db-mariadb11.4.yml:doc/docker/elastic8.yml:doc/docker/valkey-latest.yml:doc/docker/selenium.yml"
+            ci-scripts-branch: "k8s-satis"
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             job-count: 4
             multirepository: true
@@ -53,7 +55,7 @@ jobs:
         secrets: inherit
     regression-commerce-setup3:
         name: "PHP 8.4/Node 22/MySQL 8.4/Multirepository/Solr 8/Redis latest"
-        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@k8s-satis
         with:
             project-edition: "commerce"
             project-version: ${{ github.event.inputs.project-version }}
@@ -61,6 +63,7 @@ jobs:
             test-setup-phase-1: "--profile=regression --suite=setup-commerce --tags=~@part2 --mode=standard"
             test-setup-phase-2: "--profile=regression --suite=setup-commerce --tags=@part2 --mode=standard"
             setup: "doc/docker/base-dev.yml:doc/docker/db-mysql8.4.yml:doc/docker/solr8.yml:doc/docker/redis-latest.yml:doc/docker/selenium.yml"
+            ci-scripts-branch: "k8s-satis"
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             job-count: 4
             multirepository: true
@@ -69,11 +72,12 @@ jobs:
         secrets: inherit
     admin-ui-connector-quable:
         name: "Connector-quable tests/PHP 8.4/Node 22/PostgreSQL 18.0"
-        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@k8s-satis
         with:
             project-edition: "commerce"
             project-version: ${{ github.event.inputs.project-version }}
             setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql18.yml:doc/docker/selenium.yml"
+            ci-scripts-branch: "k8s-satis"
             install-connector-quable: true
             test-suite: '--profile=browser --suite=admin-ui-full --tags=@IbexaCommerce'
             test-setup-phase-1: '--profile=setup --suite=personas --mode=standard'

--- a/dependencies.json
+++ b/dependencies.json
@@ -96,6 +96,42 @@
             "repositoryUrl": "https://github.com/ibexa/order-management",
             "package": "ibexa/order-management",
             "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/oauth2-server",
+            "package": "ibexa/oauth2-server",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/page-builder",
+            "package": "ibexa/page-builder",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/fieldtype-matrix",
+            "package": "ibexa/fieldtype-matrix",
+            "shouldBeAddedAsVCS": false
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/shopping-list",
+            "package": "ibexa/shopping-list",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/site-context",
+            "package": "ibexa/site-context",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/user",
+            "package": "ibexa/user",
+            "shouldBeAddedAsVCS": false
         }
     ]
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -132,6 +132,12 @@
             "repositoryUrl": "https://github.com/ibexa/discounts-codes",
             "package": "ibexa/discounts-codes",
             "shouldBeAddedAsVCS": false
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/activity-log",
+            "package": "ibexa/activity-log",
+            "shouldBeAddedAsVCS": false
         }
     ]
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -5,19 +5,19 @@
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/core",
             "package": "ibexa/core",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/core-persistence",
             "package": "ibexa/core-persistence",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/doctrine-schema",
             "package": "ibexa/doctrine-schema",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
@@ -29,7 +29,7 @@
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/doctrine-migrations",
             "package": "ibexa/doctrine-migrations",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",

--- a/dependencies.json
+++ b/dependencies.json
@@ -138,6 +138,12 @@
             "repositoryUrl": "https://github.com/ibexa/activity-log",
             "package": "ibexa/activity-log",
             "shouldBeAddedAsVCS": false
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/collaboration",
+            "package": "ibexa/collaboration",
+            "shouldBeAddedAsVCS": false
         }
     ]
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -60,6 +60,12 @@
             "repositoryUrl": "https://github.com/ibexa/connector-payum",
             "package": "ibexa/connector-payum",
             "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/measurement",
+            "package": "ibexa/measurement",
+            "shouldBeAddedAsVCS": true
         }
     ]
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -126,6 +126,12 @@
             "repositoryUrl": "https://github.com/ibexa/user",
             "package": "ibexa/user",
             "shouldBeAddedAsVCS": false
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/discounts-codes",
+            "package": "ibexa/discounts-codes",
+            "shouldBeAddedAsVCS": false
         }
     ]
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -66,6 +66,12 @@
             "repositoryUrl": "https://github.com/ibexa/measurement",
             "package": "ibexa/measurement",
             "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/workflow",
+            "package": "ibexa/workflow",
+            "shouldBeAddedAsVCS": true
         }
     ]
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -99,12 +99,6 @@
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
-            "repositoryUrl": "https://github.com/ibexa/oauth2-server",
-            "package": "ibexa/oauth2-server",
-            "shouldBeAddedAsVCS": false
-        },
-        {
-            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/page-builder",
             "package": "ibexa/page-builder",
             "shouldBeAddedAsVCS": false

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,0 +1,65 @@
+{
+    "recipesEndpoint": "",
+    "packages": [
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/core",
+            "package": "ibexa/core",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/core-persistence",
+            "package": "ibexa/core-persistence",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/doctrine-schema",
+            "package": "ibexa/doctrine-schema",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/installer",
+            "package": "ibexa/installer",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/doctrine-migrations",
+            "package": "ibexa/doctrine-migrations",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/migrations",
+            "package": "ibexa/migrations",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/taxonomy",
+            "package": "ibexa/taxonomy",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/product-catalog",
+            "package": "ibexa/product-catalog",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/fieldtype-page",
+            "package": "ibexa/fieldtype-page",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/connector-payum",
+            "package": "ibexa/connector-payum",
+            "shouldBeAddedAsVCS": true
+        }
+    ]
+}

--- a/dependencies.json
+++ b/dependencies.json
@@ -90,6 +90,12 @@
             "repositoryUrl": "https://github.com/ibexa/site-factory",
             "package": "ibexa/site-factory",
             "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/order-management",
+            "package": "ibexa/order-management",
+            "shouldBeAddedAsVCS": true
         }
     ]
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -23,7 +23,7 @@
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/installer",
             "package": "ibexa/installer",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
@@ -35,43 +35,43 @@
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/migrations",
             "package": "ibexa/migrations",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/taxonomy",
             "package": "ibexa/taxonomy",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/product-catalog",
             "package": "ibexa/product-catalog",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/fieldtype-page",
             "package": "ibexa/fieldtype-page",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/connector-payum",
             "package": "ibexa/connector-payum",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/measurement",
             "package": "ibexa/measurement",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/workflow",
             "package": "ibexa/workflow",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
@@ -83,31 +83,31 @@
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/discounts",
             "package": "ibexa/discounts",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/site-factory",
             "package": "ibexa/site-factory",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/order-management",
             "package": "ibexa/order-management",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/oauth2-server",
             "package": "ibexa/oauth2-server",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/page-builder",
             "package": "ibexa/page-builder",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
@@ -119,13 +119,13 @@
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/shopping-list",
             "package": "ibexa/shopping-list",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
             "repositoryUrl": "https://github.com/ibexa/site-context",
             "package": "ibexa/site-context",
-            "shouldBeAddedAsVCS": true
+            "shouldBeAddedAsVCS": false
         },
         {
             "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",

--- a/dependencies.json
+++ b/dependencies.json
@@ -72,6 +72,24 @@
             "repositoryUrl": "https://github.com/ibexa/workflow",
             "package": "ibexa/workflow",
             "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/system-info",
+            "package": "ibexa/system-info",
+            "shouldBeAddedAsVCS": false
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/discounts",
+            "package": "ibexa/discounts",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-dbal-4-upgrade as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/site-factory",
+            "package": "ibexa/site-factory",
+            "shouldBeAddedAsVCS": true
         }
     ]
 }


### PR DESCRIPTION
https://github.com/ibexa/doctrine-schema/pull/45
https://github.com/ibexa/core/pull/800
https://github.com/ibexa/core-persistence/pull/39
https://github.com/ibexa/installer/pull/217
https://github.com/ibexa/doctrine-migrations/pull/6
https://github.com/ibexa/migrations/pull/447
https://github.com/ibexa/taxonomy/pull/438
https://github.com/ibexa/product-catalog/pull/1563
https://github.com/ibexa/fieldtype-page/pull/218
https://github.com/ibexa/connector-payum/pull/44

Not listed, deliberately:

- https://github.com/ibexa/test-core/pull/35 — development tooling, `prepare_project_edition.sh` adds every listed package to the project's `require`, and this one does not belong in an installed project.
- https://github.com/ibexa/data-intelligence-layer/pull/45 — no edition declares it, so forcing it in would exercise a setup nobody ships. Covered by its own pipeline.

Each package is flagged `shouldBeAddedAsVCS` so Composer resolves the branch straight from GitHub. Satis lagged behind a force push more than once while this work was in progress, and a regression run silently resolving a stale commit is worse than a slower one.

What this build is expected to catch that the package pipelines cannot:

- The per-package `Browser tests` jobs fail on all four of core, product-catalog, taxonomy and fieldtype-page with `Your requirements could not be resolved`, because an inline alias only applies in the root package and `ibexa/oss` pulls these transitively at `~6.0.x-dev`. Here the branches are added to the project's own `require`, so the alias holds and the stack resolves as one.
- MariaDB. No package pipeline in the organisation runs it, and DBAL 4 reparents `MariaDBPlatform` off `MySQLPlatform`, which already broke the Random sort clause once during this work. Setup 2 covers MariaDB 11.4.
- A real installation rather than a test fixture: schema generated by the installer, on MySQL 8.4, MariaDB 11.4 and PostgreSQL 18, with Solr and Elasticsearch.

Databases are created fresh here, so this exercises the new `utf8mb4_unicode_520_ci` DDL rather than the upgrade path. Converting an existing database is a separate procedure — two console commands plus the SQL script in `ibexa/installer` — and is not covered by this run.
