### PR TITLE
Run regression for IBX-11964

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -21,7 +21,7 @@ on:
 jobs:
     regression-commerce-setup1:
         name: "PHP 8.3/Node 22/PostgreSQL 18.0/Varnish/Redis 7.2/Multirepository"
-        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@k8s-satis
         with:
             project-edition: "commerce"
             project-version: ${{ github.event.inputs.project-version }}
@@ -29,6 +29,7 @@ jobs:
             test-setup-phase-1: "--profile=regression --suite=setup-commerce --tags=~@part2 --mode=standard"
             test-setup-phase-2: "--profile=regression --suite=setup-commerce --tags=@part2 --mode=standard"
             setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql18.yml:doc/docker/varnish.yml:doc/docker/redis7.2.yml:doc/docker/selenium.yml"
+            ci-scripts-branch: "k8s-satis"
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             job-count: 4
             multirepository: true
@@ -37,7 +38,7 @@ jobs:
         secrets: inherit
     regression-commerce-setup2:
         name: "PHP 8.4/Node 22/MariaDB 11.4/Elastic 8/Valkey latest"
-        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@k8s-satis
         with:
             project-edition: "commerce"
             project-version: ${{ github.event.inputs.project-version }}
@@ -45,6 +46,7 @@ jobs:
             test-setup-phase-1: "--profile=regression --suite=setup-commerce --tags=~@part2 --mode=standard"
             test-setup-phase-2: "--profile=regression --suite=setup-commerce --tags=@part2 --mode=standard"
             setup: "doc/docker/base-dev.yml:doc/docker/db-mariadb11.4.yml:doc/docker/elastic8.yml:doc/docker/valkey-latest.yml:doc/docker/selenium.yml"
+            ci-scripts-branch: "k8s-satis"
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             job-count: 4
             multirepository: true
@@ -53,7 +55,7 @@ jobs:
         secrets: inherit
     regression-commerce-setup3:
         name: "PHP 8.4/Node 22/MySQL 8.4/Multirepository/Solr 8/Redis latest"
-        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@k8s-satis
         with:
             project-edition: "commerce"
             project-version: ${{ github.event.inputs.project-version }}
@@ -61,6 +63,7 @@ jobs:
             test-setup-phase-1: "--profile=regression --suite=setup-commerce --tags=~@part2 --mode=standard"
             test-setup-phase-2: "--profile=regression --suite=setup-commerce --tags=@part2 --mode=standard"
             setup: "doc/docker/base-dev.yml:doc/docker/db-mysql8.4.yml:doc/docker/solr8.yml:doc/docker/redis-latest.yml:doc/docker/selenium.yml"
+            ci-scripts-branch: "k8s-satis"
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             job-count: 4
             multirepository: true

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -72,11 +72,12 @@ jobs:
         secrets: inherit
     admin-ui-connector-quable:
         name: "Connector-quable tests/PHP 8.4/Node 22/PostgreSQL 18.0"
-        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@k8s-satis
         with:
             project-edition: "commerce"
             project-version: ${{ github.event.inputs.project-version }}
             setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql18.yml:doc/docker/selenium.yml"
+            ci-scripts-branch: "k8s-satis"
             install-connector-quable: true
             test-suite: '--profile=browser --suite=admin-ui-full --tags=@IbexaCommerce'
             test-setup-phase-1: '--profile=setup --suite=personas --mode=standard'

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "https://updates.ibexa.co"
+            "url": "https://satis.services.ibexa.co"
         }
     ],
     "require": {

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,0 +1,29 @@
+{
+    "recipesEndpoint": "https://api.github.com/repos/ibexa/recipes-dev/contents/index.json?ref=flex/pull-256",
+    "packages": [
+        {
+            "requirement": "dev-IBX-11964-app-switcher as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/admin-ui",
+            "package": "ibexa/admin-ui",
+            "shouldBeAddedAsVCS": false
+        },
+        {
+            "requirement": "dev-IBX-11964-remove-app-switcher as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/headless",
+            "package": "ibexa/headless",
+            "shouldBeAddedAsVCS": false
+        },
+        {
+            "requirement": "dev-IBX-11964-remove-app-switcher as 6.0.x-dev",
+            "repositoryUrl": "https://github.com/ibexa/engage",
+            "package": "ibexa/engage",
+            "shouldBeAddedAsVCS": true
+        },
+        {
+            "requirement": "dev-IBX-11964-app-switcher as dev-6.0-next",
+            "repositoryUrl": "https://github.com/ibexa/admin-ui-assets",
+            "package": "ibexa/admin-ui-assets",
+            "shouldBeAddedAsVCS": false
+        }
+    ]
+}


### PR DESCRIPTION
Regression tests for: [#1997](https://github.com/ibexa/admin-ui/pull/1997) [#256](https://github.com/ibexa/recipes-dev/pull/256) [#298](https://github.com/ibexa/headless/pull/298) [#7](https://github.com/ibexa/engage/pull/7)

Combined state also includes:

- [ibexa/design-system#127](https://github.com/ibexa/design-system/pull/127) — not a Composer package, so it rides in through the CI-only build branch [`admin-ui-assets#IBX-11964-app-switcher`](https://github.com/ibexa/admin-ui-assets/tree/IBX-11964-app-switcher) (pinned `as dev-6.0-next`).
- [ibexa/recipes-dev#256](https://github.com/ibexa/recipes-dev/pull/256) via `recipesEndpoint` → `flex/pull-256`, so the generated project no longer registers `IbexaAppSwitcherBundle`.

Throwaway branch — never merged.
